### PR TITLE
add princeton travel info

### DIFF
--- a/pages/travel-princeton.md
+++ b/pages/travel-princeton.md
@@ -1,0 +1,72 @@
+---
+layout: page
+show_meta: false
+title: "Travel Information"
+subheadline: "Information for participants traveling to Princeton"
+permalink: "/travel-princeton/"
+---
+
+## COVID-19 Policy
+All participants must to adhere to all Princeton University [guidelines, policies, and protocols for visitors and conferences](https://covid.princeton.edu/policies) in place at the time of the workshop.
+As of June, 2022, this would require attesting to vaccination prior to arrival.
+
+
+## General Notes
+A hotel block has been reserved at the Nassau Inn in Princeton, NJ, located adjacent to
+the Princeton University campus.  
+The workshop will be held on campus in Jadwin Hall.
+It may be useful to review the [University webpages](http://www.princeton.edu/main/visiting/) about traveling to and visiting Princeton.
+
+Please send any questions about travel to the workshop to Andrea Rubinstein or Ian Cosden.
+
+## Travel Reimbursement
+Participants receiving travel support will be sent instructions via email.  
+
+
+## Travel by Train
+From Newark Liberty International (EWR) airport, John F. Kennedy International
+Airport (JFK), and from many other locations along the east coast (e.g., Boston, NYC,
+Washington DC, and Baltimore), it is possible to travel to Princeton by train.
+Note that there are two train stations you will need to know:
+
+The major train station closest to Princeton is "Princeton Junction Station"
+(PJC). This is served by New Jersey Transit on the "Northeast Corridor Line".
+PJC also has some limited direct service by Amtrak. The campus train station is
+"Princeton Station". This is served only by a small commuter train (the "Dinky")
+which goes along a spur line from Princeton Junction Station to campus. It is
+operated by New Jersey Transit. If you are coming from EWR, Trenton or NYC Penn
+Station, you should buy a New Jersey Transit ticket through to Princeton
+Station. You will then need to take a train to Princeton Junction train station
+(check that your particular train stops there!), get off at Princeton Junction
+train station and take the "Dinky" from Princeton Junction train station to
+Princeton train station. From the Princeton train station it is about a 15
+minute walk to the Nassau Inn. Uber and Lyft should be possible on and around
+Princeton University campus, the town of Princeton, and Princeton Junction train
+station.
+
+If you are coming on Amtrak, most trains do not stop at Princeton Junction
+(with only a few exceptions, see the Amtrak website).
+You will need to take Amtrak to Newark or Trenton and then switch to New Jersey
+Transit, as above, to get to Princeton Junction Station and then to Princeton Station on campus.
+
+## Travel by Air
+The closest and most convenient airport to come to Princeton is Newark Liberty
+International (EWR). Most participants will find that the best solution for
+domestic flights within the US. This is the recommended airport unless the cost
+is significantly higher than other alternatives. From there it is convenient to
+take the train as described above.
+
+The next closest airport is Philadelphia International (PHL) but will require
+a 60 min+ Uber/Lyft ride to Princeton.
+Another option is flying into John F. Kennedy International Airport (JFK) or
+LaGuardia International Airport (LGA) at the cost of additional travel time.
+From JFK, the easiest is probably to the Airtrain to Jamaica Station and then
+take the Long Island Rail Road (LIRR) to New York Penn Station. Alternatively
+there is the subway or a bus (NYC Airporter with service from JFK to NYC Penn
+Station. From NYC Penn Station, you can take the train to Princeton as described
+above.
+
+From a small number of locations it may also be possible to fly to
+Trenton-Mercer Airport. Getting from there to the Princeton campus is more
+complicated and involves using an Uber or Lyft, buses, and/or going to the train
+station in Trenton and taking New Jersey Transit trains, as above.  


### PR DESCRIPTION
Adds a page for travel guidance to Princeton. It's not linked from anywhere, but I don't think that's a big problem for now. We can send it and link to it directly. 