### PR TITLE
Update site for bootcamp'25 announcement

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -18,7 +18,7 @@
   side: left
   dropdown:
     - title: "Bootcamp25"
-      url: "/bootcamp25-announce/"
+      url: "/bootcamp25/"
     - title: "Bootcamp24"
       url: "/bootcamp24/"
     - title: "Bootcamp23"

--- a/_posts/2025-02-07
+++ b/_posts/2025-02-07
@@ -1,0 +1,17 @@
+---
+layout: page
+title:  "2025 INTERSECT Bootcamp Applications Open"
+categories:
+    - announcement
+tags:
+header: no
+author: cosden
+image:
+    title: intersect-poster.jpg
+    thumb: intersect-poster.jpg
+    homepage: intersect-poster.jpg
+---
+
+We are excited to announce that we have opened [applications](https://docs.google.com/forms/d/e/1FAIpQLScQsrtJYD9l25xdo_bUjuow5hsWe_DXcQ0M0zT7fwuXBgL8Pw/viewform?usp=dialog) for the [2025 INTERSECT Bootcamp]({{site.url}}{{site.baseurl}}/bootcamp25/). 
+
+Please [contact us](https://intersect-training.org/contact/) for more details.

--- a/pages/bootcamps.md
+++ b/pages/bootcamps.md
@@ -49,6 +49,6 @@ For those with less experience we recommend the excellent material from The Carp
 
 ### Registration
 
-More information for the 2024 INTERSECT bootcamp can be found on the [bootcamp24 page]( {{site.url}}{{site.baseurl}}/bootcamp24/).
+More information for the 2025 INTERSECT bootcamp can be found on the [bootcamp24 page]( {{site.url}}{{site.baseurl}}/bootcamp25/).
 
 <a class="radius button small" href="{{ site.url }}{{ site.baseurl }}/participate/">Sign up for mailing list updates ›</a>

--- a/pages/bootcamps/bootcamp25.md
+++ b/pages/bootcamps/bootcamp25.md
@@ -1,0 +1,19 @@
+---
+layout: page
+show_meta: false
+title: "INTERSECT Bootcamp '25"
+subheadline: "Third INTERSECT Bootcamp"
+teaser: "July 14-18, Princeton University"
+header:
+permalink: "/bootcamp25/"
+---
+The INTERSECT Research Software Engineering Bootcamp will be a 4.5 day intensive hands-on workshop focusing on practices that will help research software developers improve the quality, reproducibility, and sustainability of their software.  
+# Application
+Please see the [Bootcamp25 Announcement page]({{site.url}}{{site.baseurl}}/bootcamp25-announce/).
+
+# Agenda
+The full agenda for the bootcamp will be published closer to the event. 
+(Last year's agenda is available [here]({{site.url}}{{site.baseurl}}/bootcamp24/).)
+
+# Questions
+Please email Ian Cosden (icosden@princeton.edu) and/or Jeff Carver (carver@cs.ua.edu).

--- a/pages/participate.md
+++ b/pages/participate.md
@@ -9,6 +9,9 @@ header:
 permalink: "/participate/"
 ---
 
+## Bootcamp 2025
+See the [Bootcamp25 page]({{ site.url }}{{ site.baseurl }}/bootcamp25) for details, participation options, and application information.
+
 ## Bootcamp 2024
 See the [Bootcamp24 page]({{ site.url }}{{ site.baseurl }}/bootcamp24) for details, participation options, and application information.
 


### PR DESCRIPTION
This adds a short post to the front page about applications for the 25 bootcamp being open. Don't merge it yet. I _think_ we need to do two things first:
1. Add a redirect or change the name of the announce page. This way we don't have a dead link to the announce page.
2. Add the date this will posted to be 2/7/25
I will update here. 