### PR TITLE
Update Advisory Board

### DIFF
--- a/pages/team.md
+++ b/pages/team.md
@@ -17,12 +17,16 @@ header:
 
 
 * [David E. Bernholdt](https://csmd.ornl.gov/profile/david-bernholdt), Computer Science and Mathematics Division, Oak Ridge National Laboratory
+* [Peter Elmer](https://scholar.princeton.edu/elmer), Princeton University / Institute for Research and Innovation in Software for High-Energy Physics (IRIS-HEP)
+* [Sandra Gesing](http://sandra-gesing.com/), US Research Software Engineer Association (US-RSE) & San Diego Supercomputer Center
+* [Daniel S. Katz](http://danielskatz.org/), University of Illinois Urbana-Champaign
+* Lauren Milichen, MIT
+* Miranda Mundt, Sandia National Laboratories
+
+## Former Advisory Board Members
 * [Alys Brett](https://www.linkedin.com/in/alysbrett/), UK Atomic Energy Authority
 * [Anshu Dubey](https://www.anl.gov/profile/anshu-dubey), Argonne National Laboratory / University of Chicago
-* [Peter Elmer](https://scholar.princeton.edu/elmer), Princeton University / Institute for Research and Innovation in Software for High-Energy Physics (IRIS-HEP)
-* [Sandra Gesing](http://sandra-gesing.com/), Discovery Partner Institute at the University of Illinois Chicago
 * [Mozhgan Kabiri chimeh](http://mkchimeh.com/), NVIDIA
-* [Daniel S. Katz](http://danielskatz.org/), University of Illinois Urbana-Champaign
 
 
 ## Contributors

--- a/pages/team.md
+++ b/pages/team.md
@@ -21,7 +21,7 @@ header:
 * [Sandra Gesing](http://sandra-gesing.com/), US Research Software Engineer Association (US-RSE) & San Diego Supercomputer Center
 * [Daniel S. Katz](http://danielskatz.org/), University of Illinois Urbana-Champaign
 * Lauren Milechin, MIT
-* Miranda Mundt, Sandia National Laboratories
+* [Miranda Mundt](https://mrmundt.github.io), Sandia National Laboratories
 
 ## Former Advisory Board Members
 * [Alys Brett](https://www.linkedin.com/in/alysbrett/), UK Atomic Energy Authority

--- a/pages/team.md
+++ b/pages/team.md
@@ -20,7 +20,7 @@ header:
 * [Peter Elmer](https://scholar.princeton.edu/elmer), Princeton University / Institute for Research and Innovation in Software for High-Energy Physics (IRIS-HEP)
 * [Sandra Gesing](http://sandra-gesing.com/), US Research Software Engineer Association (US-RSE) & San Diego Supercomputer Center
 * [Daniel S. Katz](http://danielskatz.org/), University of Illinois Urbana-Champaign
-* Lauren Milechin, MIT
+* [Lauren Milechin](https://www.linkedin.com/in/lauren-milechin/), MIT
 * [Miranda Mundt](https://mrmundt.github.io), Sandia National Laboratories
 
 ## Former Advisory Board Members

--- a/pages/team.md
+++ b/pages/team.md
@@ -20,7 +20,7 @@ header:
 * [Peter Elmer](https://scholar.princeton.edu/elmer), Princeton University / Institute for Research and Innovation in Software for High-Energy Physics (IRIS-HEP)
 * [Sandra Gesing](http://sandra-gesing.com/), US Research Software Engineer Association (US-RSE) & San Diego Supercomputer Center
 * [Daniel S. Katz](http://danielskatz.org/), University of Illinois Urbana-Champaign
-* Lauren Milichen, MIT
+* Lauren Milechin, MIT
 * Miranda Mundt, Sandia National Laboratories
 
 ## Former Advisory Board Members


### PR DESCRIPTION
This moves the former AB members to a new category and adds the new AB members. 

Before merging I need to check with Miranda and Lauren if they want their names linked to a page. 