### PR TITLE
Create bootcamp26.md

### DIFF
--- a/pages/bootcamps/bootcamp26.md
+++ b/pages/bootcamps/bootcamp26.md
@@ -97,7 +97,7 @@ Additionally, participants should be comfortable managing their own development 
 <a name="sponsors"></a>
 # Sponsors
 Travel funding is provided via NSF.  
-Thanks to the [Princeton AI Lab]((https://ai.princeton.edu/ai-lab)) for fully supporting the Tuesday evening reception and [Princeton Research Computing](https://researchcomputing.princeton.edu/) for supporting the Monday evening reception.
+Thanks to the [Princeton AI Lab](https://ai.princeton.edu/ai-lab) for fully supporting the Tuesday evening reception and [Princeton Research Computing](https://researchcomputing.princeton.edu/) for supporting the Monday evening reception.
 
 # Questions
 Please email Ian Cosden (icosden@princeton.edu) and/or Jeff Carver (carver@cs.ua.edu).

--- a/pages/bootcamps/bootcamp26.md
+++ b/pages/bootcamps/bootcamp26.md
@@ -1,0 +1,103 @@
+---
+layout: page
+show_meta: false
+title: "INTERSECT Bootcamp '26"
+subheadline: "Fourth Annual INTERSECT Bootcamp"
+teaser: "July 13-17, Princeton University"
+header:
+permalink: "/bootcamp26/"
+---
+The INTERSECT Research Software Engineering Bootcamp will be a 4.5 day intensive hands-on workshop focusing on practices that will help research software developers improve the quality, reproducibility, and sustainability of their software.  
+
+# Agenda
+
+All instruction sessions will take place at Princeton University, Room 138 [Lewis Library](https://maps.app.goo.gl/AxXdnym8RyguLjSZ9).
+
+### Day 1 - Monday, July 13
+
+| Time | Session Title | Instructor(s) |
+| 8:00 - 8:45 | Registration & Breakfast |   |
+| 8:45 - 9:00 | Welcome & Introduction | Ian Cosden & Jeff Carver |
+| 9:00 - 10:15 | Project Management Part 1 | Miranda Mundt |
+| 10:15 - 10:30 | Break | |
+| 10:30 - 11:15 | Project Management Part 2 | Miranda Mundt |
+| 11:15 - 12:15 | Design Part 1 | Abbey Roelofs |
+| 12:15 - 1:15 | Lunch |  |
+| 1:15 - 3:00 | Design Part 2 | Abbey Roelofs |
+| 3:00 - 3:15 | Break | |
+| 3:15 - 4:45 | Licensing | TBD |
+| 5:00 - 7:00 | Welcome Reception & Dinner | TBD |
+
+*The Monday evening reception & dinner is [sponsored](#sponsors) by [Princeton Research Computing](https://researchcomputing.princeton.edu/).
+
+### Day 2 - Tuesday, July 14
+
+| Time | Session Title | Instructor(s) |
+| 8:30 - 9:00 | Breakfast |  |
+| 9:00 - 9:15 | Working Collaboratively Intro | Lauren Milechin |
+| 9:15 - 10:30 | Collaborative Git Part 1 | Lauren Milechin |
+| 10:30 - 10:45 | Break | |
+| 10:45 - 12:00 | Collaborative Git Part 2 | Lauren Milechin |
+| 12:00 - 1:00 | Lunch | | 
+| 1:00 - 2:00 | Issue Tracking | Miranda Mundt |
+| 2:00 - 3:00 | Making Good PRs | Miranda Mundt |
+| 3:00 - 3:15 | Break | |
+| 3:15 - 4:45 | Better Documentation | Miranda Mundt |
+| 6:00 - 9:00 | Reception Dinner at [Palmer House](https://palmerhouse.princeton.edu/)|  |
+
+*The Tuesday evening reception dinner is [sponsored](#sponsors) by the [Princeton AI Lab](https://ai.princeton.edu/ai-lab).
+
+### Day 3 - Wednesday, July 15
+
+| Time | Session Title | Instructor(s) |
+| 8:30 - 9:00 | Breakfast |  |
+| 9:00 - 10:30 | Code Review Part 1 | Abbey Roelofs |
+| 10:30 - 10:45 | Break |  |
+| 10:45 - 12:15 | Code Review Part 2 | Abbey Roelofs |
+| 12:15 - 12:30 | Group Photo |  |
+| 12:30 - | Lunch |  |
+
+*Note: no formal bootcamp activities are planned for Wednesday afternoon.
+Participants may use this time to explore the area, connect with other participants, or just decompress.
+
+### Day 4 - Thursday, July 16
+
+| Time | Session Title | Instructor(s)
+| 8:30 - 9:00 | Breakfast | | 
+| 9:00 - 10:45 | Packaging & Distribution Part 1 | George Dang |
+| 10:45 - 11:00 | Break | |
+| 11:00 - 12:15 | Packaging & Distribution Part 2 | George Dang |
+| 12:15 - 1:15 | Lunch |  |
+| 1:15 - 3:00 | Testing Part 1 | Gabe Perez-Giz |
+| 3:00 - 3:15 | Break | |
+| 3:15 - 4:30 | Testing Part 2 | Gabe Perez-Giz |
+
+### Day 5 - Friday, July 17
+
+| Time | Session Title | Instructor(s) |
+| 8:30 - 9:00 | Breakfast |  |
+| 9:00- 10:30 | CI/CD Part 1 | Julia Damerow |
+| 10:30 - 10:45 | Break | |
+| 10:45 - 11:45 | CI/CD Part 2 | Julia Damerow |
+| 11:45 - 12:00 | Survey & Final Remarks | Ian Cosden & Jeff Carver |
+| 12:00 - | Boxed To-Go Lunch | |
+
+# Meals
+During the workshop we will provide breakfast and lunch (M-F) for all participants.
+Dinner will be provided on Monday and Tuesday, other days are on your own.
+
+# Preparation
+We expect attendees to come with a basic background in programming.
+Previous, formal computer science (CS) training is specifically not a prerequisite.
+Rather, we expect many, if not most attendees to be self-taught programmers coming from non-CS domains.
+Where possible, we will aim to keep instruction uncoupled from specific languages or technologies.
+Because this is nearly impossible, we expect attendees to have a working knowledge of python, basic git commands and functionality, competency with an editor, and experience working with the command line.
+Additionally, participants should be comfortable managing their own development environment on their laptop.
+
+<a name="sponsors"></a>
+# Sponsors
+Travel funding is provided via NSF.  
+Thanks to the [Princeton AI Lab]((https://ai.princeton.edu/ai-lab)) for fully supporting the Tuesday evening reception and [Princeton Research Computing](https://researchcomputing.princeton.edu/) for supporting the Monday evening reception.
+
+# Questions
+Please email Ian Cosden (icosden@princeton.edu) and/or Jeff Carver (carver@cs.ua.edu).


### PR DESCRIPTION
This adds the 2026 bootcamp agenda page. It probably shouldn't be merged until the nav links are changed too, but let's check this first. 